### PR TITLE
Update cross-site frame counting with a new example in GitHub

### DIFF
--- a/content/docs/attacks/frame-counting.md
+++ b/content/docs/attacks/frame-counting.md
@@ -77,6 +77,9 @@ Some examples of frame counting attacks are:
 
 A vulnerability reported to Facebook used this technique to leak user-related information such as specific content published in posts, religious information about friends, or photo locations[^1].
 
+A vulnerability reported to GitHub showcase how your private repositories could have been exposed[^2].
+
 ## References
 
 [^1]: Patched Facebook Vulnerability Could Have Exposed Private Information About You and Your Friends. [link](https://www.imperva.com/blog/facebook-privacy-bug/)
+[^2]: How Cross-Site Frame Counting Exposes Private Repositories on GitHub. [link](https://mr-medi.github.io/research/2023/07/31/exploring-cross-site-frame-counting-attacks.html)


### PR DESCRIPTION
Hi,

I've made an update to the **frame-counting.md** file, adding a new example that discusses a blog post I recently published. The example illustrates how cross-site frame counting can potentially expose private repositories on GitHub. I'm excited about the opportunity to contribute to your repository, especially since I've gained valuable insights from it.

Thank you for your dedicated work!